### PR TITLE
Add env command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+aws-okta

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"
-	"github.com/segmentio/aws-okta/lib"
+	"github.com/docker-infra/aws-okta/lib"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"
-	"github.com/segmentio/aws-okta/lib"
+	"github.com/docker-infra/aws-okta/lib"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 )

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/segmentio/aws-okta/lib/saml"
+	"github.com/docker-infra/aws-okta/lib/saml"
 )
 
 const (

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/segmentio/aws-okta/lib/saml"
+	"github.com/docker-infra/aws-okta/lib/saml"
 	"golang.org/x/net/html"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/segmentio/aws-okta/cmd"
+	"github.com/docker-infra/aws-okta/cmd"
 )
 
 // These are set via linker flags


### PR DESCRIPTION
For cases where you can't 'aws-okta exec' a command (for example, using shell functions that aren't in your $PATH so the Go binary doesn't know about them), the "env" command simply prints export strings that you can then eval to get the env variables set up in your shell.

Example:
```
fish$ eval (./aws-okta env infra.admin) | env | grep AWS
AWS_ACCESS_KEY_ID=ASIA2RVBF3XHT3WXLU3D
AWS_OKTA_PROFILE=infra.admin
AWS_SECRET_ACCESS_KEY=redacted
AWS_SECURITY_TOKEN=redacted
AWS_SESSION_TOKEN=redacted
```
